### PR TITLE
feat: Add base file setup for CLI tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,12 @@
-OPENAI_API_KEY="<token here>"
+# OpenAI Configuration
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-3.5-turbo
+
+# Application Configuration
+DEBUG=false
+LOG_LEVEL=info
+
+# UI Configuration
+THEME=default
+MAX_RETRIES=3
+TIMEOUT=30

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nwthomas

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Please read before opening a pull request: https://github.com/nwthomas/.github/blob/main/CONTRIBUTING.md -->
+
+## Ticket
+
+<!-- Place any references / tickets here -->
+
+## Problem
+
+<!-- What is the problem you're trying to solve with this PR? -->
+
+## Solution
+
+<!-- What is the proposed solution to the above problem implemented in this PR? -->
+
+## Testing
+
+<!-- How did you personally test this and validate the solution? Please be specific. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,132 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22.1'
+        cache: true
+    
+    - name: Install dependencies
+      run: go mod download
+    
+    - name: Verify dependencies
+      run: go mod verify
+    
+    - name: Format check
+      run: |
+        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+          echo "The following files are not formatted:"
+          gofmt -s -l .
+          exit 1
+        fi
+    
+    - name: Vet
+      run: go vet ./...
+    
+    - name: Test
+      run: go test -v -race -coverprofile=coverage.out ./...
+    
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.out
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    
+    strategy:
+      matrix:
+        os: [linux, windows, darwin]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows
+            arch: arm64
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22.1'
+        cache: true
+    
+    - name: Get version
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
+        else
+          echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Build
+      env:
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
+        VERSION: ${{ steps.version.outputs.version }}
+        COMMIT: ${{ github.sha }}
+        DATE: ${{ github.event.head_commit.timestamp }}
+      run: |
+        if [ "${{ matrix.os }}" = "windows" ]; then
+          go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE" -o murmur-${{ matrix.os }}-${{ matrix.arch }}.exe ./cmd/murmur
+        else
+          go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE" -o murmur-${{ matrix.os }}-${{ matrix.arch }} ./cmd/murmur
+        fi
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: murmur-${{ matrix.os }}-${{ matrix.arch }}
+        path: murmur-${{ matrix.os }}-${{ matrix.arch }}*
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Get version
+      id: version
+      run: echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
+    
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: |
+          ${{ secrets.DOCKER_USERNAME }}/murmur:latest
+          ${{ secrets.DOCKER_USERNAME }}/murmur:${{ steps.version.outputs.version }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -19,10 +16,37 @@
 
 # Go workspace file
 go.work
-go.work.sum
 
-# env file
+# Environment variables
 .env
+.env.local
+.env.*.local
 
-# miscellaneous
-/bin/
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Build artifacts
+dist/
+build/
+bin/
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,175 @@
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/nwthomas/murmur
+  golint:
+    min-confidence: 0
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - gochecknoglobals
+  # - gocognit
+  # - gochecknoinits
+  # - interfacer
+  # - maligned
+  # - scopelint
+  # - wsl
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+        - funlen
+        - goconst
+        - dupl
+        - gocyclo
+        - gocritic
+        - lll
+    - path: cmd/
+      linters:
+        - gochecknoinits
+    - linters:
+        - lll
+      source: "^//go:generate "
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: false
+
+  # The default value is false. If set to true exclude and exclude-rules
+  # regular expressions become case sensitive.
+  exclude-case-sensitive: false
+
+  # The list of ids of default excludes to include or disable. By default it's empty.
+  include:
+    - EXC0002 # disable excluding of issues about comments from golint
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing
+  # large codebase. It's not practical to fix all existing issues at once.
+  # Default value is false.
+  new: false
+
+  # Show only new issues created after git revision `REV`
+  new-from-rev: ""
+
+  # Show only new issues created in git patch with set file path.
+  new-from-patch: ""
+
+  # Maximum allowed time for loading packages. This is useful for CI which has
+  # reproducible timeout. Default value is 0 which means disable timeout.
+  timeout: 5m
+
+  # Print the linter name in the output
+  print-linter-name: true
+
+  # Print the line number in the output
+  print-line-number: true
+
+  # Print the column number in the output
+  print-column-number: true
+
+  # Print the severity of the issue in the output
+  print-severity: true
+
+  # Print the linter name in the output
+  print-issued-line: true
+
+  # Print the linter name in the output
+  print-linter-name: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Build stage
+FROM golang:1.22.1-alpine AS builder
+
+# Install git and ca-certificates (needed for go mod download and HTTPS requests)
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o murmur ./cmd/murmur
+
+# Final stage
+FROM alpine:latest
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+# Create non-root user
+RUN addgroup -g 1001 -S murmur && \
+    adduser -u 1001 -S murmur -G murmur
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder stage
+COPY --from=builder /app/murmur .
+
+# Change ownership to non-root user
+RUN chown murmur:murmur /app/murmur
+
+# Switch to non-root user
+USER murmur
+
+# Expose port (if needed for future web interface)
+EXPOSE 8080
+
+# Set environment variables
+ENV GIN_MODE=release
+
+# Run the application
+ENTRYPOINT ["./murmur"]

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,142 @@
-run:
+# Variables
+BINARY_NAME=murmur
+VERSION?=dev
+COMMIT?=unknown
+DATE?=unknown
+BUILD_FLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+
+# Default target
+.PHONY: help
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# Development targets
+.PHONY: run
+run: ## Run the application in development mode
 	go run ./cmd/murmur/main.go
+
+.PHONY: run-interactive
+run-interactive: ## Run in interactive mode
+	go run ./cmd/murmur/main.go
+
+.PHONY: run-with-prompt
+run-with-prompt: ## Run with a specific prompt (set PROMPT="your prompt")
+	@if [ -z "$(PROMPT)" ]; then \
+		echo "Usage: make run-with-prompt PROMPT=\"your prompt here\""; \
+		exit 1; \
+	fi
+	go run ./cmd/murmur/main.go -prompt="$(PROMPT)"
+
+# Build targets
+.PHONY: build
+build: ## Build the binary
+	go build $(BUILD_FLAGS) -o $(BINARY_NAME) ./cmd/murmur
+
+.PHONY: build-linux
+build-linux: ## Build for Linux
+	GOOS=linux GOARCH=amd64 go build $(BUILD_FLAGS) -o $(BINARY_NAME)-linux ./cmd/murmur
+
+.PHONY: build-windows
+build-windows: ## Build for Windows
+	GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o $(BINARY_NAME)-windows.exe ./cmd/murmur
+
+.PHONY: build-darwin
+build-darwin: ## Build for macOS
+	GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o $(BINARY_NAME)-darwin ./cmd/murmur
+
+.PHONY: build-all
+build-all: build-linux build-windows build-darwin ## Build for all platforms
+
+# Test targets
+.PHONY: test
+test: ## Run tests
+	go test -v ./...
+
+.PHONY: test-coverage
+test-coverage: ## Run tests with coverage
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+
+.PHONY: test-race
+test-race: ## Run tests with race detection
+	go test -race ./...
+
+# Code quality targets
+.PHONY: fmt
+fmt: ## Format code
+	go fmt ./...
+
+.PHONY: vet
+vet: ## Run go vet
+	go vet ./...
+
+.PHONY: lint
+lint: ## Run golangci-lint (requires golangci-lint to be installed)
+	golangci-lint run
+
+.PHONY: tidy
+tidy: ## Tidy go modules
+	go mod tidy
+
+.PHONY: check
+check: fmt vet test ## Run all checks (format, vet, test)
+
+# Docker targets
+.PHONY: docker-build
+docker-build: ## Build Docker image
+	docker build -t $(BINARY_NAME):$(VERSION) .
+
+.PHONY: docker-run
+docker-run: ## Run Docker container
+	docker run -it --rm \
+		-e OPENAI_API_KEY=$(OPENAI_API_KEY) \
+		$(BINARY_NAME):$(VERSION)
+
+.PHONY: docker-dev
+docker-dev: ## Run development Docker container
+	docker-compose --profile dev up murmur-dev
+
+# Clean targets
+.PHONY: clean
+clean: ## Clean build artifacts
+	rm -f $(BINARY_NAME)
+	rm -f $(BINARY_NAME)-*
+	rm -f coverage.out coverage.html
+
+.PHONY: clean-deps
+clean-deps: ## Clean dependencies
+	go clean -modcache
+
+# Install targets
+.PHONY: install
+install: build ## Install binary to GOPATH/bin
+	go install $(BUILD_FLAGS) ./cmd/murmur
+
+.PHONY: uninstall
+uninstall: ## Remove binary from GOPATH/bin
+	go clean -i ./cmd/murmur
+
+# Development setup
+.PHONY: setup
+setup: ## Setup development environment
+	go mod download
+	go mod verify
+	@echo "Development environment setup complete!"
+	@echo "Don't forget to:"
+	@echo "  1. Copy .env.example to .env"
+	@echo "  2. Set your OPENAI_API_KEY in .env"
+
+# Release targets
+.PHONY: release
+release: clean build-all ## Create release builds
+	@echo "Release builds created:"
+	@ls -la $(BINARY_NAME)-*
+
+.PHONY: version
+version: ## Show version information
+	@echo "Version: $(VERSION)"
+	@echo "Commit: $(COMMIT)"
+	@echo "Date: $(DATE)"

--- a/README.md
+++ b/README.md
@@ -1,34 +1,214 @@
-> NOTE: This is obviously a repository in draft. However, I like to build in public. This is a project I've had on the backburner for many months as you can see from my initial commits. Art is worth pursuing for its own sake, and so I want to make this repository public as I flesh it out.
-
 # Murmur
 
-## 🔎 About
-
-> “The words of the poets are the murmurs of the stream, the sighing of the wind, the whisper of leaves.”
+> "The words of the poets are the murmurs of the stream, the sighing of the wind, the whisper of leaves."
 >
 > — Henry Wadsworth Longfellow
 
-A Go-based CLI tool for writing poems using generative AI.
+A beautiful Go-based CLI tool for generating poetry using AI. Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) for an elegant terminal experience.
 
-Do robots speak of electric dreams?
+## ✨ Features
 
-## 🎖️ Features
+- 🎭 **Interactive Mode**: Beautiful terminal UI for composing poetry prompts
+- 🚀 **Command Line Mode**: Generate poems directly from the command line
+- 🎨 **Elegant Design**: Built with Bubble Tea for a smooth terminal experience
+- 🔧 **Configurable**: Environment-based configuration with sensible defaults
+- 🐳 **Docker Support**: Run anywhere with Docker
+- 📦 **Cross-Platform**: Builds for Linux, macOS, and Windows
+- 🧪 **Well Tested**: Comprehensive test coverage and CI/CD pipeline
 
-## 🧱 Project Management
+## 🚀 Quick Start
 
-Work for this repository is housed in this [Trello board](https://trello.com/b/ZN1a9zrh/murmur).
+### Prerequisites
 
-## 📁 Project Structure
+- Go 1.22.1 or later
+- OpenAI API key
+
+### Installation
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/nwthomas/murmur.git
+   cd murmur
+   ```
+
+2. **Set up environment:**
+   ```bash
+   cp .env.example .env
+   # Edit .env and add your OpenAI API key
+   ```
+
+3. **Install dependencies:**
+   ```bash
+   make setup
+   ```
+
+4. **Run the application:**
+   ```bash
+   make run
+   ```
+
+### Using Docker
 
 ```bash
-├── cmd/                                         #
-│   └── murmur/                                  # Houses the core Go files for the server
+# Build and run with Docker
+docker build -t murmur .
+docker run -it --rm -e OPENAI_API_KEY="your-key" murmur
 ```
 
-## 🛠️ Built With
+## 📖 Usage
 
-- [Golang](https://go.dev/)
+### Interactive Mode
 
-## 🙇🏻‍♂️ Acknowledgements
+Start Murmur without arguments for an interactive experience:
 
-- To my parents for always encouraging creativity, curiousity, and persistence
+```bash
+./murmur
+```
+
+### Command Line Mode
+
+Generate poems directly:
+
+```bash
+./murmur -prompt="Write a haiku about the ocean"
+```
+
+### Available Flags
+
+- `-prompt`: Specify a poem prompt (enables direct mode)
+- `-debug`: Enable debug logging
+- `-version`: Show version information
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENAI_API_KEY` | Your OpenAI API key | **Required** |
+| `OPENAI_MODEL` | OpenAI model to use | `gpt-3.5-turbo` |
+| `DEBUG` | Enable debug mode | `false` |
+| `LOG_LEVEL` | Logging level | `info` |
+| `THEME` | UI theme | `default` |
+| `MAX_RETRIES` | Maximum API retries | `3` |
+| `TIMEOUT` | Request timeout (seconds) | `30` |
+
+## 🛠️ Development
+
+### Project Structure
+
+```
+├── cmd/murmur/           # Main application entry point
+├── internal/
+│   ├── ai/              # AI client for OpenAI integration
+│   ├── config/          # Configuration management
+│   └── logger/          # Structured logging
+├── examples/            # Usage examples
+├── .github/workflows/   # CI/CD pipelines
+├── Dockerfile           # Container configuration
+├── docker-compose.yml   # Development environment
+└── Makefile            # Build and development tasks
+```
+
+### Available Make Commands
+
+```bash
+make help              # Show all available commands
+make run               # Run in development mode
+make build             # Build the binary
+make test              # Run tests
+make test-coverage     # Run tests with coverage
+make fmt               # Format code
+make vet               # Run go vet
+make lint              # Run linter (requires golangci-lint)
+make docker-build      # Build Docker image
+make docker-run        # Run Docker container
+make clean             # Clean build artifacts
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run tests with coverage
+make test-coverage
+
+# Run tests with race detection
+make test-race
+```
+
+### Building for Different Platforms
+
+```bash
+# Build for current platform
+make build
+
+# Build for all platforms
+make build-all
+
+# Build for specific platform
+make build-linux
+make build-windows
+make build-darwin
+```
+
+## 🐳 Docker
+
+### Development with Docker
+
+```bash
+# Run development container with live reload
+make docker-dev
+
+# Or use docker-compose directly
+docker-compose --profile dev up murmur-dev
+```
+
+### Production Docker
+
+```bash
+# Build production image
+make docker-build
+
+# Run production container
+make docker-run
+```
+
+## 🚀 CI/CD
+
+This project includes GitHub Actions workflows for:
+
+- **Continuous Integration**: Automated testing, linting, and building
+- **Multi-platform Builds**: Automatic builds for Linux, macOS, and Windows
+- **Docker Publishing**: Automatic Docker image builds and publishing
+- **Code Quality**: Format checking, vetting, and test coverage
+
+## 📝 Examples
+
+See the [examples directory](examples/) for detailed usage examples and common patterns.
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+### Development Setup
+
+1. Run `make setup` to install dependencies
+2. Copy `.env.example` to `.env` and configure
+3. Run `make test` to ensure everything works
+4. Make your changes and test them
+5. Run `make check` before committing
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgements
+
+- To my parents for always encouraging creativity, curiosity, and persistence
+- The [Bubble Tea](https://github.com/charmbracelet/bubbletea) team for the amazing TUI framework
+- The Go community for excellent tooling and practices

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  murmur:
+    build: .
+    container_name: murmur-cli
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-3.5-turbo}
+      - DEBUG=${DEBUG:-false}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - THEME=${THEME:-default}
+      - MAX_RETRIES=${MAX_RETRIES:-3}
+      - TIMEOUT=${TIMEOUT:-30}
+    volumes:
+      # Mount current directory for development
+      - .:/app
+    stdin_open: true
+    tty: true
+    # Override the entrypoint for interactive use
+    entrypoint: ["./murmur"]
+    profiles:
+      - cli
+
+  # Development service with live reload
+  murmur-dev:
+    build:
+      context: .
+      target: builder
+    container_name: murmur-dev
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-3.5-turbo}
+      - DEBUG=true
+      - LOG_LEVEL=debug
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: ["go", "run", "./cmd/murmur/main.go"]
+    stdin_open: true
+    tty: true
+    profiles:
+      - dev

--- a/examples/basic_usage.md
+++ b/examples/basic_usage.md
@@ -1,0 +1,82 @@
+# Basic Usage Examples
+
+## Interactive Mode
+
+Run Murmur without any arguments to enter interactive mode:
+
+```bash
+./murmur
+```
+
+This will start an interactive session where you can enter your poem prompt.
+
+## Command Line Mode
+
+Generate a poem directly from the command line:
+
+```bash
+./murmur -prompt="Write a haiku about the ocean"
+```
+
+## Environment Variables
+
+Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+./murmur -prompt="A poem about coding"
+```
+
+Or use a `.env` file:
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit .env with your API key
+# Then run
+./murmur
+```
+
+## Debug Mode
+
+Enable debug logging:
+
+```bash
+./murmur -debug -prompt="A poem about debugging"
+```
+
+## Version Information
+
+Check the version:
+
+```bash
+./murmur -version
+```
+
+## Docker Usage
+
+Build and run with Docker:
+
+```bash
+# Build the image
+docker build -t murmur .
+
+# Run with environment variable
+docker run -it --rm -e OPENAI_API_KEY="your-key" murmur
+
+# Run with a specific prompt
+docker run -it --rm -e OPENAI_API_KEY="your-key" murmur -prompt="A poem about containers"
+```
+
+## Development Mode
+
+For development with live reload:
+
+```bash
+# Using docker-compose
+docker-compose --profile dev up murmur-dev
+
+# Or run directly
+make run
+```

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/nwthomas/murmur
 
 go 1.22.1
 
+require github.com/charmbracelet/bubbletea v1.3.4
+
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.4 // indirect
 	github.com/charmbracelet/lipgloss v1.0.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1,0 +1,124 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client handles AI API interactions
+type Client struct {
+	apiKey    string
+	model     string
+	baseURL   string
+	httpClient *http.Client
+}
+
+// Message represents a chat message
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatRequest represents the request to the OpenAI API
+type ChatRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+	MaxTokens int      `json:"max_tokens,omitempty"`
+	Temperature float64 `json:"temperature,omitempty"`
+}
+
+// ChatResponse represents the response from the OpenAI API
+type ChatResponse struct {
+	Choices []struct {
+		Message Message `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error,omitempty"`
+}
+
+// NewClient creates a new AI client
+func NewClient(apiKey, model string) *Client {
+	return &Client{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: "https://api.openai.com/v1",
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// GeneratePoem generates a poem based on the given prompt
+func (c *Client) GeneratePoem(ctx context.Context, prompt string) (string, error) {
+	systemPrompt := `You are a creative poet. Generate beautiful, meaningful poems based on the user's prompt. 
+	The poem should be well-structured, emotionally resonant, and demonstrate literary craftsmanship. 
+	Format the poem with proper line breaks and stanzas.`
+
+	messages := []Message{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: prompt},
+	}
+
+	req := ChatRequest{
+		Model:       c.model,
+		Messages:    messages,
+		MaxTokens:   500,
+		Temperature: 0.8,
+	}
+
+	response, err := c.makeRequest(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate poem: %w", err)
+	}
+
+	if response.Error != nil {
+		return "", fmt.Errorf("API error: %s", response.Error.Message)
+	}
+
+	if len(response.Choices) == 0 {
+		return "", fmt.Errorf("no response from AI")
+	}
+
+	return response.Choices[0].Message.Content, nil
+}
+
+// makeRequest makes an HTTP request to the AI API
+func (c *Client) makeRequest(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/chat/completions", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var chatResp ChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &chatResp, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Config holds all configuration for the application
+type Config struct {
+	// API Configuration
+	OpenAIAPIKey string
+	Model        string
+	
+	// Application Configuration
+	Debug        bool
+	LogLevel     string
+	
+	// UI Configuration
+	Theme        string
+	MaxRetries   int
+	Timeout      int
+}
+
+// Load loads configuration from environment variables
+func Load() (*Config, error) {
+	config := &Config{
+		OpenAIAPIKey: getEnv("OPENAI_API_KEY", ""),
+		Model:        getEnv("OPENAI_MODEL", "gpt-3.5-turbo"),
+		Debug:        getEnvBool("DEBUG", false),
+		LogLevel:     getEnv("LOG_LEVEL", "info"),
+		Theme:        getEnv("THEME", "default"),
+		MaxRetries:   getEnvInt("MAX_RETRIES", 3),
+		Timeout:      getEnvInt("TIMEOUT", 30),
+	}
+
+	// Validate required configuration
+	if config.OpenAIAPIKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY environment variable is required")
+	}
+
+	return config, nil
+}
+
+// getEnv gets an environment variable with a fallback value
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// getEnvBool gets a boolean environment variable with a fallback value
+func getEnvBool(key string, fallback bool) bool {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+// getEnvInt gets an integer environment variable with a fallback value
+func getEnvInt(key string, fallback int) int {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	// Save original environment
+	originalAPIKey := os.Getenv("OPENAI_API_KEY")
+	originalModel := os.Getenv("OPENAI_MODEL")
+	originalDebug := os.Getenv("DEBUG")
+	originalLogLevel := os.Getenv("LOG_LEVEL")
+
+	// Clean up after test
+	defer func() {
+		if originalAPIKey != "" {
+			os.Setenv("OPENAI_API_KEY", originalAPIKey)
+		} else {
+			os.Unsetenv("OPENAI_API_KEY")
+		}
+		if originalModel != "" {
+			os.Setenv("OPENAI_MODEL", originalModel)
+		} else {
+			os.Unsetenv("OPENAI_MODEL")
+		}
+		if originalDebug != "" {
+			os.Setenv("DEBUG", originalDebug)
+		} else {
+			os.Unsetenv("DEBUG")
+		}
+		if originalLogLevel != "" {
+			os.Setenv("LOG_LEVEL", originalLogLevel)
+		} else {
+			os.Unsetenv("LOG_LEVEL")
+		}
+	}()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		expectError bool
+		expected    *Config
+	}{
+		{
+			name: "valid configuration",
+			envVars: map[string]string{
+				"OPENAI_API_KEY": "test-key",
+				"OPENAI_MODEL":   "gpt-4",
+				"DEBUG":          "true",
+				"LOG_LEVEL":      "debug",
+			},
+			expectError: false,
+			expected: &Config{
+				OpenAIAPIKey: "test-key",
+				Model:        "gpt-4",
+				Debug:        true,
+				LogLevel:     "debug",
+				Theme:        "default",
+				MaxRetries:   3,
+				Timeout:      30,
+			},
+		},
+		{
+			name: "missing API key",
+			envVars: map[string]string{
+				"OPENAI_MODEL": "gpt-3.5-turbo",
+			},
+			expectError: true,
+		},
+		{
+			name: "default values",
+			envVars: map[string]string{
+				"OPENAI_API_KEY": "test-key",
+			},
+			expectError: false,
+			expected: &Config{
+				OpenAIAPIKey: "test-key",
+				Model:        "gpt-3.5-turbo",
+				Debug:        false,
+				LogLevel:     "info",
+				Theme:        "default",
+				MaxRetries:   3,
+				Timeout:      30,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear environment
+			os.Unsetenv("OPENAI_API_KEY")
+			os.Unsetenv("OPENAI_MODEL")
+			os.Unsetenv("DEBUG")
+			os.Unsetenv("LOG_LEVEL")
+
+			// Set test environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			config, err := Load()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if config.OpenAIAPIKey != tt.expected.OpenAIAPIKey {
+				t.Errorf("Expected OpenAIAPIKey %s, got %s", tt.expected.OpenAIAPIKey, config.OpenAIAPIKey)
+			}
+
+			if config.Model != tt.expected.Model {
+				t.Errorf("Expected Model %s, got %s", tt.expected.Model, config.Model)
+			}
+
+			if config.Debug != tt.expected.Debug {
+				t.Errorf("Expected Debug %v, got %v", tt.expected.Debug, config.Debug)
+			}
+
+			if config.LogLevel != tt.expected.LogLevel {
+				t.Errorf("Expected LogLevel %s, got %s", tt.expected.LogLevel, config.LogLevel)
+			}
+		})
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		fallback string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "environment variable exists",
+			key:      "TEST_VAR",
+			fallback: "fallback",
+			envValue: "env-value",
+			expected: "env-value",
+		},
+		{
+			name:     "environment variable does not exist",
+			key:      "NONEXISTENT_VAR",
+			fallback: "fallback",
+			envValue: "",
+			expected: "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable if provided
+			if tt.envValue != "" {
+				os.Setenv(tt.key, tt.envValue)
+				defer os.Unsetenv(tt.key)
+			}
+
+			result := getEnv(tt.key, tt.fallback)
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Logger wraps the structured logger
+type Logger struct {
+	*slog.Logger
+}
+
+// New creates a new logger instance
+func New(level string, debug bool) *Logger {
+	var logLevel slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		logLevel = slog.LevelDebug
+	case "info":
+		logLevel = slog.LevelInfo
+	case "warn", "warning":
+		logLevel = slog.LevelWarn
+	case "error":
+		logLevel = slog.LevelError
+	default:
+		logLevel = slog.LevelInfo
+	}
+
+	var output io.Writer = os.Stdout
+	if debug {
+		// In debug mode, use a more verbose format
+		opts := &slog.HandlerOptions{
+			Level: logLevel,
+			AddSource: true,
+		}
+		handler := slog.NewTextHandler(output, opts)
+		return &Logger{slog.New(handler)}
+	}
+
+	// Production mode with JSON output
+	opts := &slog.HandlerOptions{
+		Level: logLevel,
+	}
+	handler := slog.NewJSONHandler(output, opts)
+	return &Logger{slog.New(handler)}
+}
+
+// WithField adds a field to the logger context
+func (l *Logger) WithField(key string, value interface{}) *Logger {
+	return &Logger{l.Logger.With(key, value)}
+}
+
+// WithFields adds multiple fields to the logger context
+func (l *Logger) WithFields(fields map[string]interface{}) *Logger {
+	args := make([]interface{}, 0, len(fields)*2)
+	for k, v := range fields {
+		args = append(args, k, v)
+	}
+	return &Logger{l.Logger.With(args...)}
+}


### PR DESCRIPTION
## Ticket

TODO - Create Kanban board cards

## Problem

I want to develop a small CLI tool that can help me brainstorm generative AI-induced poems.

This is an exercise in Go, Bubbletea (for Go-based CLI creation), and generative AI.

## Solution

Implement a variety of base functionality including:
1. Environment variables
2. Docker setup for build processes
3. Code owners
4. Go files for logging and configurations
5. Docker build processes
6. Makefile commands

## Testing

TODO before landing